### PR TITLE
feat: migrate from jcenter to maven

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/alarmscheduler/build.gradle
+++ b/alarmscheduler/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 
 android {
     compileSdkVersion 29

--- a/alarmscheduler/build.gradle
+++ b/alarmscheduler/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion 29
@@ -39,13 +38,3 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
 }
-
-publish {
-    userOrg = 'kazafchen'
-    repoName = 'Library'
-    groupId = 'com.carterchen247'
-    artifactId = 'alarm-scheduler'
-    publishVersion = '1.0.4'
-    desc = 'Alarm scheduler'
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+apply from: "${rootDir}/scripts/publish-root.gradle"
 
 buildscript {
     ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()
-        
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
+        classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -20,7 +22,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.novoda:bintray-release:0.9.2'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -1,0 +1,62 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+def libraryVersion = '1.0.4'
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                artifact androidSourcesJar
+                groupId 'com.carterchen247'
+                artifactId 'alarm-scheduler'
+                version libraryVersion
+
+                // ref: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom
+                pom {
+                    name = 'Alarm scheduler'
+                    description = 'Alarm scheduler'
+                    url = 'https://github.com/CarterChen247/AlarmScheduler'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/CarterChen247/AlarmScheduler'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'carterchen247'
+                            name = 'Carter Chen'
+                            email = 'carterchen247@gmail.com'
+                        }
+                    }
+
+                    // ref: https://maven.apache.org/pom.html#SCM
+                    scm {
+                        connection = 'scm:git:https://github.com/CarterChen247/AlarmScheduler.git'
+                        developerConnection = 'scm:git:https://github.com/CarterChen247/AlarmScheduler.git'
+                        url = 'https://github.com/CarterChen247/AlarmScheduler.git'
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ref: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials
+ext["signing.keyId"] = rootProject.ext["signing.keyId"]
+ext["signing.password"] = rootProject.ext["signing.password"]
+ext["signing.secretKeyRingFile"] = rootProject.ext["signing.secretKeyRingFile"]
+
+signing {
+    sign publishing.publications
+}

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -1,0 +1,20 @@
+// Use system environment variables
+ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+ext["signing.key"] = System.getenv('SIGNING_KEY')
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -4,7 +4,7 @@ ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
 ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
 ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
 ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-ext["signing.key"] = System.getenv('SIGNING_KEY')
+ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
 
 // Set up Sonatype repository
 nexusPublishing {


### PR DESCRIPTION
Since JCenter is going to shut down, we are going to use MavenCentral to serve library dependencies. The code changes include:

- Gradle script migrating from JCenter to Maven Central
- `build.gradle` files modularization

references:
- https://medium.com/mobile-app-development-publication/upload-to-mavencentral-made-easy-for-android-library-30d2b83af0c7
- https://chris.banes.dev/publishing-to-maven-central/
- https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/