### PR TITLE
feat: request ACTION_REQUEST_SCHEDULE_EXACT_ALARM more easily

### DIFF
--- a/alarmscheduler/src/main/java/com/carterchen247/alarmscheduler/extension/ActivityExtension.kt
+++ b/alarmscheduler/src/main/java/com/carterchen247/alarmscheduler/extension/ActivityExtension.kt
@@ -2,11 +2,17 @@ package com.carterchen247.alarmscheduler.extension
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 
 fun Activity.openExactAlarmSettingPage() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+        startActivity(
+            Intent(
+                Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM,
+                Uri.parse("package:$packageName")
+            )
+        )
     }
 }


### PR DESCRIPTION
when alarms & reminders permission is not granted, guide user to the permission page directly.