### PR TITLE
refactor: rename the class "EventBus" to "MessageDispatcher" to avoid confusion with the EventBus library

### DIFF
--- a/app/src/main/java/com/carterchen247/alarmscheduler/demo/App.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/demo/App.kt
@@ -2,7 +2,7 @@ package com.carterchen247.alarmscheduler.demo
 
 import android.app.Application
 import com.carterchen247.alarmscheduler.AlarmScheduler
-import com.carterchen247.alarmscheduler.demo.log.EventBus
+import com.carterchen247.alarmscheduler.demo.log.MessageDispatcher
 import com.carterchen247.alarmscheduler.error.AlarmSchedulerErrorHandler
 import com.carterchen247.alarmscheduler.logger.AlarmSchedulerLogger
 import com.carterchen247.alarmscheduler.task.AlarmTask
@@ -15,6 +15,7 @@ class App : Application() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
 
+
         AlarmScheduler.setAlarmTaskFactory(object : AlarmTaskFactory {
             override fun createAlarmTask(alarmType: Int): AlarmTask {
                 return DemoAlarmTask()
@@ -24,7 +25,7 @@ class App : Application() {
         AlarmScheduler.setErrorHandler(object : AlarmSchedulerErrorHandler {
             override fun handleError(error: Throwable) {
                 Timber.e(error)
-                EventBus.dispatchMessage("error occurs, error=$error")
+                MessageDispatcher.dispatchMessage("error occurs, error=$error")
             }
         })
     }

--- a/app/src/main/java/com/carterchen247/alarmscheduler/demo/DemoAlarmTask.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/demo/DemoAlarmTask.kt
@@ -1,9 +1,8 @@
 package com.carterchen247.alarmscheduler.demo
 
-import com.carterchen247.alarmscheduler.demo.log.EventBus
+import com.carterchen247.alarmscheduler.demo.log.MessageDispatcher
 import com.carterchen247.alarmscheduler.model.DataPayload
 import com.carterchen247.alarmscheduler.task.AlarmTask
-import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 
 class DemoAlarmTask : AlarmTask {
@@ -20,6 +19,6 @@ class DemoAlarmTask : AlarmTask {
         """.trimIndent()
 
         val dataPayloadString = GsonBuilder().setPrettyPrinting().create().toJson(dataPayload)
-        EventBus.dispatchMessage(msg + dataPayloadString)
+        MessageDispatcher.dispatchMessage(msg + dataPayloadString)
     }
 }

--- a/app/src/main/java/com/carterchen247/alarmscheduler/demo/MainActivity.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/demo/MainActivity.kt
@@ -8,9 +8,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.carterchen247.alarmscheduler.demo.databinding.ActivityMainBinding
-import com.carterchen247.alarmscheduler.demo.log.EventBus
 import com.carterchen247.alarmscheduler.demo.log.ListItem
 import com.carterchen247.alarmscheduler.demo.log.ListItemAdapter
+import com.carterchen247.alarmscheduler.demo.log.MessageDispatcher
 import com.carterchen247.alarmscheduler.extension.openExactAlarmSettingPage
 import java.time.LocalDateTime
 import kotlin.math.max
@@ -36,7 +36,7 @@ class MainActivity : AppCompatActivity(), MainView {
             presenter.requestScheduledAlarmsInfo()
         }
 
-        EventBus.setObserver { msg ->
+        MessageDispatcher.subscribeMessage { msg ->
             val now = LocalDateTime.now()
             addListItem(ListItem(msg, now.toString()))
         }

--- a/app/src/main/java/com/carterchen247/alarmscheduler/demo/log/MessageDispatcher.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/demo/log/MessageDispatcher.kt
@@ -1,13 +1,13 @@
 package com.carterchen247.alarmscheduler.demo.log
 
-object EventBus {
+object MessageDispatcher {
     private var observer: ((String) -> Unit)? = null
 
     fun dispatchMessage(msg: String) {
         observer?.invoke(msg)
     }
 
-    fun setObserver(observer: ((String) -> Unit)) {
+    fun subscribeMessage(observer: ((String) -> Unit)) {
         this.observer = observer
     }
 }


### PR DESCRIPTION
### AS-IS
The naming "EventBus" may confuse people to the EventBus library

### TO-BE
Replace the naming "EventBus" with "MessageDispatcher"