### PR TITLE
refactor(app): hide implementations details of initialization of the RecyclerView to AbstractListActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,10 +30,6 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-
-    buildFeatures {
-        viewBinding true
-    }
 }
 
 dependencies {

--- a/app/src/main/java/com/carterchen247/alarmscheduler/AbstractListActivity.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/AbstractListActivity.kt
@@ -1,0 +1,64 @@
+package com.carterchen247.alarmscheduler
+
+import android.graphics.Rect
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.carterchen247.alarmscheduler.demo.MainPresenter
+import com.carterchen247.alarmscheduler.demo.MainView
+import com.carterchen247.alarmscheduler.demo.R
+import com.carterchen247.alarmscheduler.demo.log.ListItem
+import com.carterchen247.alarmscheduler.demo.log.ListItemAdapter
+import kotlin.math.max
+
+abstract class AbstractListActivity : AppCompatActivity(), MainView {
+
+    protected val presenter by lazy { MainPresenter(this) }
+    private val listItemAdapter by lazy { ListItemAdapter() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        initListView()
+        presenter.init()
+    }
+
+    private fun initListView() {
+        findViewById<RecyclerView>(R.id.listView).run {
+            addItemDecoration(createItemDecoration())
+            layoutManager = LinearLayoutManager(this@AbstractListActivity)
+            adapter = listItemAdapter
+        }
+    }
+
+    override fun addListItem(item: ListItem) {
+        runOnUiThread {
+            listItemAdapter.addItem(item)
+            scrollToBottom()
+        }
+    }
+
+    private fun scrollToBottom() {
+        findViewById<RecyclerView>(R.id.listView).scrollToPosition(max(0, listItemAdapter.itemCount - 1))
+    }
+
+    private fun createItemDecoration(): RecyclerView.ItemDecoration {
+        return object : RecyclerView.ItemDecoration() {
+            override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+                val dividerHeight = resources.getDimension(R.dimen.divider_height).toInt()
+                val position = parent.getChildLayoutPosition(view)
+                if (position == 0) {
+                    outRect.top = dividerHeight
+                }
+                outRect.bottom = dividerHeight
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        presenter.destroy()
+    }
+}

--- a/app/src/main/java/com/carterchen247/alarmscheduler/demo/MainActivity.kt
+++ b/app/src/main/java/com/carterchen247/alarmscheduler/demo/MainActivity.kt
@@ -1,38 +1,24 @@
 package com.carterchen247.alarmscheduler.demo
 
-import android.graphics.Rect
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.carterchen247.alarmscheduler.demo.databinding.ActivityMainBinding
+import com.carterchen247.alarmscheduler.AbstractListActivity
 import com.carterchen247.alarmscheduler.demo.log.ListItem
-import com.carterchen247.alarmscheduler.demo.log.ListItemAdapter
 import com.carterchen247.alarmscheduler.demo.log.MessageDispatcher
 import com.carterchen247.alarmscheduler.extension.openExactAlarmSettingPage
 import java.time.LocalDateTime
-import kotlin.math.max
 
-class MainActivity : AppCompatActivity(), MainView {
-
-    private lateinit var binding: ActivityMainBinding
-    private val presenter by lazy { MainPresenter(this) }
-    private val listItemAdapter by lazy { ListItemAdapter() }
+class MainActivity : AbstractListActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        initListView()
-        presenter.init()
 
-        binding.btnSchedule.setOnClickListener {
+        findViewById<View>(R.id.btnSchedule).setOnClickListener {
             presenter.scheduleAlarm()
         }
 
-        binding.btnGetScheduledAlarmsInfo.setOnClickListener {
+        findViewById<View>(R.id.btnGetScheduledAlarmsInfo).setOnClickListener {
             presenter.requestScheduledAlarmsInfo()
         }
 
@@ -40,11 +26,6 @@ class MainActivity : AppCompatActivity(), MainView {
             val now = LocalDateTime.now()
             addListItem(ListItem(msg, now.toString()))
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        presenter.destroy()
     }
 
     override fun showExactAlarmPermissionSetupDialog() {
@@ -57,37 +38,5 @@ class MainActivity : AppCompatActivity(), MainView {
             .setNegativeButton("cancel") { _, _ -> }
             .create()
             .show()
-    }
-
-    private fun initListView() {
-        binding.listView.run {
-            addItemDecoration(createItemDecoration())
-            layoutManager = LinearLayoutManager(this@MainActivity)
-            adapter = listItemAdapter
-        }
-    }
-
-    override fun addListItem(item: ListItem) {
-        runOnUiThread {
-            listItemAdapter.addItem(item)
-            scrollToBottom()
-        }
-    }
-
-    private fun scrollToBottom() {
-        binding.listView.scrollToPosition(max(0, listItemAdapter.itemCount - 1))
-    }
-
-    private fun createItemDecoration(): RecyclerView.ItemDecoration {
-        return object : RecyclerView.ItemDecoration() {
-            override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-                val dividerHeight = resources.getDimension(R.dimen.divider_height).toInt()
-                val position = parent.getChildLayoutPosition(view)
-                if (position == 0) {
-                    outRect.top = dividerHeight
-                }
-                outRect.bottom = dividerHeight
-            }
-        }
     }
 }


### PR DESCRIPTION
### AS-IS
- Too many responsibilities in `MainActivity`, making it hard to demonstrate the library's features effectively.

### TO-BE
- Move unrelated implementations to `AbstractListActivity` to better focus on the library's features.